### PR TITLE
Update metadata for streams even if URI doesn't change

### DIFF
--- a/src/sonos-device.ts
+++ b/src/sonos-device.ts
@@ -550,8 +550,11 @@ export class SonosDevice extends SonosDeviceBase {
       }
     }
 
-    this.currentTrackUri = data.CurrentTrackURI
-    this.Events.emit(SonosEvents.CurrentTrack, this.currentTrackUri);
+    if (data.CurrentTrackURI && this.currentTrackUri !== data.CurrentTrackURI) {
+      this.currentTrackUri = data.CurrentTrackURI
+      this.Events.emit(SonosEvents.CurrentTrack, this.currentTrackUri);
+    }
+    
     if(data.CurrentTrackMetaData) this.Events.emit(SonosEvents.CurrentTrackMetadata, data.CurrentTrackMetaData)
 
     if (data.NextTrackURI && this.nextTrackUri !== data.NextTrackURI) {

--- a/src/sonos-device.ts
+++ b/src/sonos-device.ts
@@ -550,11 +550,9 @@ export class SonosDevice extends SonosDeviceBase {
       }
     }
 
-    if (data.CurrentTrackURI && this.currentTrackUri !== data.CurrentTrackURI) {
-      this.currentTrackUri = data.CurrentTrackURI
-      this.Events.emit(SonosEvents.CurrentTrack, this.currentTrackUri);
-      if(data.CurrentTrackMetaData) this.Events.emit(SonosEvents.CurrentTrackMetadata, data.CurrentTrackMetaData)
-    }
+    this.currentTrackUri = data.CurrentTrackURI
+    this.Events.emit(SonosEvents.CurrentTrack, this.currentTrackUri);
+    if(data.CurrentTrackMetaData) this.Events.emit(SonosEvents.CurrentTrackMetadata, data.CurrentTrackMetaData)
 
     if (data.NextTrackURI && this.nextTrackUri !== data.NextTrackURI) {
       this.nextTrackUri = data.NextTrackURI


### PR DESCRIPTION
I removed the check for changed track URI. The check prevented the update of track meta data for radio streams. When a stream is played the track URI doesn't change but the track meta is constantly updated.

As a side effect, the meta data events are now published periodically even if the meta data didn't change. So an open question is: Is there a way to identify if the meta data changed from one event to another?