### PR TITLE
Improve parsing r:StreamContent

### DIFF
--- a/src/helpers/metadata-helper.ts
+++ b/src/helpers/metadata-helper.ts
@@ -36,6 +36,12 @@ export class MetadataHelper {
       if(streamContent.length === 2) {
         track.Artist = streamContent[0].trim();
         track.Title = streamContent[1].trim();
+      } else {
+        track.Artist = streamContent[0].trim();
+        if(didlItem['r:radioShowMd'] && typeof didlItem['r:radioShowMd'] === 'string') {
+          const radioShowMd = (didlItem['r:radioShowMd'] as string).split(',');
+          track.Title = radioShowMd[0].trim();
+        }
       }
     }
     if(didlItem['upnp:albumArtURI']) {


### PR DESCRIPTION
This fix improves the handling of field r:StreamContent when streaming e.g. radio stations. In case of my favorite station there isn't always a parseable artist/title combination available. Instead, only the name of the radio station is included (see below).

`
{ 'DIDL-Lite': { '_xmlns:dc': 'http://purl.org/dc/elements/1.1/', '_xmlns:upnp': 'urn:schemas-upnp-org:metadata-1-0/upnp/', '_xmlns:r': 'urn:schemas-rinconnetworks-com:metadata-1-0/', _xmlns: 'urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/', item: { _id: '-1', _parentID: '-1', _restricted: 'true', res: [Object], 'r:streamContent': 'Bremen Vier', 'r:radioShowMd': 'HeuckZeug,p270647', 'upnp:albumArtURI': '/getaa?s=1&amp;u=x-sonosapi-stream%3as25565%3fsid%3d254%26flags%3d8224%26sn%3d0', 'dc:title': 'x-sonosapi-stream:s25565?sid=254&amp;flags=8224&amp;sn=0', 'upnp:class': 'object.item' } } } 
`

This is currently parsed as follows:

```json
{
  "AlbumArtUri": "http://192.168.178.41:1400/getaa?s=1&u=x-sonosapi-stream:s25565%3fsid%3d254%26flags%3d8224%26sn%3d0",
  "Title": "x-sonosapi-stream:s25565?sid=254&amp;flags=8224&amp;sn=0",
  "UpnpClass": "object.item",
  "ItemId": "-1",
  "ParentId": "-1",
  "TrackUri": "x-sonosapi-stream:s25565?sid=254&flags=8224&sn=0",
  "ProtocolInfo": "sonos.com-http:*:*:*"
}
```

This is not nice for displaying it in my smarthome software.

The fix adds the stream content to the artist even if the content cannot be split. Additionally, 'r:radioShowMd' is parsed and added to the title. The result is this:

```json
{
  "Artist": "Bremen Vier",
  "AlbumArtUri": "http://192.168.178.41:1400/getaa?s=1&u=x-sonosapi-stream:s25565%3fsid%3d254%26flags%3d8224%26sn%3d0",
  "Title": "HeuckZeug",
  "UpnpClass": "object.item",
  "ItemId": "-1",
  "ParentId": "-1",
  "TrackUri": "x-sonosapi-stream:s25565?sid=254&flags=8224&sn=0",
  "ProtocolInfo": "sonos.com-http:*:*:*"
}
```