### PR TITLE
Parse information about stereo pairs from group state

### DIFF
--- a/src/services/zone-group-topology.service.ts
+++ b/src/services/zone-group-topology.service.ts
@@ -125,6 +125,10 @@ export interface ZoneGroup {
   members: ZoneMember[];
 }
 
+interface ChannelMapSet {
+  [channel: string]: string;
+}
+
 interface ZoneMember {
   host: string;
   port: number;
@@ -134,6 +138,7 @@ interface ZoneMember {
   MicEnabled: boolean;
   SoftwareVersion: string;
   SwGen: string;
+  ChannelMapSet?: ChannelMapSet;
 }
 
 /**
@@ -171,6 +176,7 @@ export class ZoneGroupTopologyService extends ZoneGroupTopologyServiceBase {
       MicEnabled: member.MicEnabled === 1,
       SoftwareVersion: member.SoftwareVersion,
       SwGen: member.SWGen,
+      ChannelMapSet: member.ChannelMapSet ? ZoneGroupTopologyService.ParseChannelMapSet(member.ChannelMapSet) : undefined,
     };
   }
 
@@ -188,6 +194,20 @@ export class ZoneGroupTopologyService extends ZoneGroupTopologyServiceBase {
       coordinator,
       members,
     };
+  }
+
+  private static ParseChannelMapSet(channelMapSet: string): ChannelMapSet {
+    const channels = channelMapSet.split(';');
+    return channels.map(channel => {
+      const [uuid, channelId] = channel.split(',');
+      return {
+        uuid: uuid.split(':')[0],
+        channelId
+      }
+    }).reduce<ChannelMapSet>((channels, channel) => {
+      channels[channel.channelId] = channel.uuid;
+      return channels;
+    }, {});
   }
 
   protected ResolveEventPropertyValue(name: string, originalValue: any, type: string): any {

--- a/src/services/zone-group-topology.service.ts
+++ b/src/services/zone-group-topology.service.ts
@@ -198,15 +198,17 @@ export class ZoneGroupTopologyService extends ZoneGroupTopologyServiceBase {
 
   private static ParseChannelMapSet(channelMapSet: string): ChannelMapSet {
     const channels = channelMapSet.split(';');
-    return channels.map(channel => {
+    return channels.map((channel) => {
       const [uuid, channelId] = channel.split(',');
       return {
         uuid: uuid.split(':')[0],
-        channelId
-      }
-    }).reduce<ChannelMapSet>((channels, channel) => {
-      channels[channel.channelId] = channel.uuid;
-      return channels;
+        channelId,
+      };
+    }).reduce<ChannelMapSet>((previousChannels, channel) => {
+      return {
+        ...previousChannels,
+        [channel.channelId]: channel.uuid,
+      };
     }, {});
   }
 

--- a/src/services/zone-group-topology.service.ts
+++ b/src/services/zone-group-topology.service.ts
@@ -118,7 +118,6 @@ export interface ZoneGroupTopologyServiceEvent {
   ZonePlayerUUIDsInGroup?: string;
 }
 
-
 export interface ZoneGroup {
   name: string;
   coordinator: ZoneMember;
@@ -204,12 +203,10 @@ export class ZoneGroupTopologyService extends ZoneGroupTopologyServiceBase {
         uuid: uuid.split(':')[0],
         channelId,
       };
-    }).reduce<ChannelMapSet>((previousChannels, channel) => {
-      return {
-        ...previousChannels,
-        [channel.channelId]: channel.uuid,
-      };
-    }, {});
+    }).reduce<ChannelMapSet>((previousChannels, channel) => ({
+      ...previousChannels,
+      [channel.channelId]: channel.uuid,
+    }), {});
   }
 
   protected ResolveEventPropertyValue(name: string, originalValue: any, type: string): any {


### PR DESCRIPTION
Adds information about stereo pairs to the parsed group information

After this change, the zone group is parsed as:

```
{ name: 'Mike&apos;s Office + 1',
  coordinator:
   { name: 'Mike&apos;s Office',
     uuid: 'RINCON_48A6B8A29E0401400',
     host: '192.168.1.21',
     port: 1400,
     Icon: 'x-rincon-roomicon:living',
     MicEnabled: false,
     SoftwareVersion: '60.3-81140',
     SwGen: '2',
     ChannelMapSet:
      { LF: 'RINCON_48A6B8A29E0401400',
        RF: 'RINCON_48A6B8A29E1801400' } },
  members:
   [ { name: 'Mike&apos;s Office',
       uuid: 'RINCON_48A6B8A29E1801400',
       host: '192.168.1.22',
       port: 1400,
       Icon: 'x-rincon-roomicon:living',
       MicEnabled: false,
       SoftwareVersion: '60.3-81140',
       SwGen: '2',
       ChannelMapSet: [Object] },
     { name: 'Mike&apos;s Office',
       uuid: 'RINCON_48A6B8A29E0401400',
       host: '192.168.1.21',
       port: 1400,
       Icon: 'x-rincon-roomicon:living',
       MicEnabled: false,
       SoftwareVersion: '60.3-81140',
       SwGen: '2',
       ChannelMapSet: [Object] } ] }
```