### PR TITLE
fix: Add apple music metadata

### DIFF
--- a/docs/sonos-device/methods.md
+++ b/docs/sonos-device/methods.md
@@ -72,6 +72,12 @@ Currently supported url's for metadata guessing:
 - `spotify:artistTopTracks:72qVrKXRp9GeFQOesj0Pmv` - Spotify artist top tracks (has to be added to queue).
 - `spotify:album:5c4y5oD0jCAVHJNusKpy4d` - Spotify album (has to be added to queue).
 - `spotify:playlist:37i9dQZF1DXcx1szy2g67M` - Spotify playlist (has to be added to queue).
+- `apple:album:1025210938` - Apple Music album (not in user's music library).
+- `apple:libraryalbum:l.OIdA15a` - Apple Music album from user's music library.
+- `apple:playlist:pl.cf589c8b40dc40cd9ddc2e61493d5efd` - Apple Music playlist (not in user's music library).
+- `apple:libraryplaylist:p.rQ5rCxE48W` - Apple Music playlist from user's music library.
+- `apple:track:1025212410` - Apple Music track (not in user's library).
+- `apple:librarytrack:i.m3g9uLvzB7` - Apple Music track from user's music library.
 - `radio:s113577` - Tunein radio station.
 
 This library will guess the metadata automatically for the following methods, but you can also use the **MetadataHelper**, yourself.

--- a/docs/sonos-device/methods.md
+++ b/docs/sonos-device/methods.md
@@ -62,6 +62,12 @@ This library can guess the required metadata for certain track uri's. This is do
 
 Currently supported url's for metadata guessing:
 
+- `apple:album:1025210938` - Apple Music album (not in user's music library).
+- `apple:libraryalbum:l.OIdA15a` - Apple Music album from user's music library.
+- `apple:libraryplaylist:p.rQ5rCxE48W` - Apple Music playlist from user's music library.
+- `apple:librarytrack:i.m3g9uLvzB7` - Apple Music track from user's music library.
+- `apple:playlist:pl.cf589c8b40dc40cd9ddc2e61493d5efd` - Apple Music playlist (not in user's music library).
+- `apple:track:1025212410` - Apple Music track (not in user's library).
 - `deezer:album:123456` - A Deezer album by id
 - `deezer:artistTopTracks:123456` - A Deezer artist top tracks
 - `deezer:playlist:123456` - A Deezer playlist by id
@@ -72,12 +78,6 @@ Currently supported url's for metadata guessing:
 - `spotify:artistTopTracks:72qVrKXRp9GeFQOesj0Pmv` - Spotify artist top tracks (has to be added to queue).
 - `spotify:album:5c4y5oD0jCAVHJNusKpy4d` - Spotify album (has to be added to queue).
 - `spotify:playlist:37i9dQZF1DXcx1szy2g67M` - Spotify playlist (has to be added to queue).
-- `apple:album:1025210938` - Apple Music album (not in user's music library).
-- `apple:libraryalbum:l.OIdA15a` - Apple Music album from user's music library.
-- `apple:playlist:pl.cf589c8b40dc40cd9ddc2e61493d5efd` - Apple Music playlist (not in user's music library).
-- `apple:libraryplaylist:p.rQ5rCxE48W` - Apple Music playlist from user's music library.
-- `apple:track:1025212410` - Apple Music track (not in user's library).
-- `apple:librarytrack:i.m3g9uLvzB7` - Apple Music track from user's music library.
 - `radio:s113577` - Tunein radio station.
 
 This library will guess the metadata automatically for the following methods, but you can also use the **MetadataHelper**, yourself.

--- a/tests/helpers/metadata-helper.test.ts
+++ b/tests/helpers/metadata-helper.test.ts
@@ -35,6 +35,80 @@ describe('MetadataHelper', () => {
     });
   });
 
+  describe('GuessTrack -> Apple Music', () => {
+    it('Guess metadata for apple:album:1025210938', () => {
+      const track = MetadataHelper.GuessTrack('apple:album:1025210938');
+      expect(track).to.have.property('TrackUri', 'x-rincon-cpcontainer:1004206calbum:1025210938?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.item.audioItem.musicAlbum');
+    });
+
+    it('Guess metadata for x-rincon-cpcontainer:1004206calbum:1025210938', () => {
+      const track = MetadataHelper.GuessTrack('x-rincon-cpcontainer:1004206calbum:1025210938');
+      expect(track).to.have.property('TrackUri', 'x-rincon-cpcontainer:1004206calbum:1025210938?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.item.audioItem.musicAlbum');
+    });
+
+    it('Guess metadata for apple:libraryalbum:l.OIdA15a', () => {
+      const track = MetadataHelper.GuessTrack('apple:libraryalbum:l.OIdA15a');
+      expect(track).to.have.property('TrackUri', 'x-rincon-cpcontainer:1004206clibraryalbum:l.OIdA15a?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.item.audioItem.musicAlbum');
+    });
+
+    it('Guess metadata for x-rincon-cpcontainer:1004206clibraryalbum:l.OIdA15a', () => {
+      const track = MetadataHelper.GuessTrack('x-rincon-cpcontainer:1004206clibraryalbum:l.OIdA15a');
+      expect(track).to.have.property('TrackUri', 'x-rincon-cpcontainer:1004206clibraryalbum:l.OIdA15a?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.item.audioItem.musicAlbum');
+    });
+
+    it('Guess metadata for apple:playlist:pl.cf589c8b40dc40cd9ddc2e61493d5efd', () => {
+      const track = MetadataHelper.GuessTrack('apple:playlist:pl.cf589c8b40dc40cd9ddc2e61493d5efd');
+      expect(track).to.have.property('TrackUri', 'x-rincon-cpcontainer:1006206cplaylist:pl.cf589c8b40dc40cd9ddc2e61493d5efd?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.container.playlistContainer');
+    });
+
+    it('Guess metadata for x-rincon-cpcontainer:1006206cplaylist:pl.cf589c8b40dc40cd9ddc2e61493d5efd?sid=204', () => {
+      const track = MetadataHelper.GuessTrack('x-rincon-cpcontainer:1006206cplaylist:pl.cf589c8b40dc40cd9ddc2e61493d5efd?sid=204');
+      expect(track).to.have.property('TrackUri', 'x-rincon-cpcontainer:1006206cplaylist:pl.cf589c8b40dc40cd9ddc2e61493d5efd?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.container.playlistContainer');
+    });
+
+    it('Guess metadata for apple:libraryplaylist:p.rQ5rCxE48W', () => {
+      const track = MetadataHelper.GuessTrack('apple:libraryplaylist:p.rQ5rCxE48W');
+      expect(track).to.have.property('TrackUri', 'x-rincon-cpcontainer:1006206clibraryplaylist:p.rQ5rCxE48W?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.container.playlistContainer');
+    });
+
+    it('Guess metadata for x-rincon-cpcontainer:1006206clibraryplaylist:p.rQ5rCxE48W?sid=204', () => {
+      const track = MetadataHelper.GuessTrack('x-rincon-cpcontainer:1006206clibraryplaylist:p.rQ5rCxE48W?sid=204');
+      expect(track).to.have.property('TrackUri', 'x-rincon-cpcontainer:1006206clibraryplaylist:p.rQ5rCxE48W?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.container.playlistContainer');
+    });
+
+    it('Guess metadata for apple:track:1025212410', () => {
+      const track = MetadataHelper.GuessTrack('apple:track:1025212410');
+      expect(track).to.have.property('TrackUri', 'x-sonos-http:song:1025212410.mp4?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.item.audioItem.musicTrack');
+    });
+
+    it('Guess metadata for x-sonos-http:song:1025212410.mp4?sid=204', () => {
+      const track = MetadataHelper.GuessTrack('x-sonos-http:song:1025212410.mp4?sid=204');
+      expect(track).to.have.property('TrackUri', 'x-sonos-http:song:1025212410.mp4?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.item.audioItem.musicTrack');
+    });
+
+    it('Guess metadata for apple:librarytrack:i.m3g9uLvzB7', () => {
+      const track = MetadataHelper.GuessTrack('apple:librarytrack:i.m3g9uLvzB7');
+      expect(track).to.have.property('TrackUri', 'x-sonos-http:librarytrack:i.m3g9uLvzB7.mp4?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.item.audioItem.musicTrack');
+    });
+
+    it('Guess metadata for x-sonos-http:librarytrack:i.m3g9uLvzB7.mp4?sid=204', () => {
+      const track = MetadataHelper.GuessTrack('x-sonos-http:librarytrack:i.m3g9uLvzB7.mp4?sid=204');
+      expect(track).to.have.property('TrackUri', 'x-sonos-http:librarytrack:i.m3g9uLvzB7.mp4?sid=204');
+      expect(track).to.have.property('UpnpClass', 'object.item.audioItem.musicTrack');
+    });
+  });
+
   describe('GuessTrack -> Deezer', () => {
     it('Guess metadata for deezer:album:169734362', () => {
       const track = MetadataHelper.GuessTrack('deezer:album:169734362');


### PR DESCRIPTION
Updated the URI and metadata guessing to allow simplified Apple Music URIs, similar to existing Spotify and Deezer support.

Apple Music uses different URIs depending on whether an item is taken from the user's music library or from the broader service. This pull request includes support for both types of content.