### PR TITLE
#141 Harden PlayNotificationTwo against some errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ docs-automatic/
 docs/_site/
 docs/.sass-cache/
 docs/vendor/
+
+# Exclude Webstorm
+.idea/

--- a/src/sonos-device.ts
+++ b/src/sonos-device.ts
@@ -1379,7 +1379,15 @@ export default class SonosDevice extends SonosDeviceBase {
         this.notificationQueue.volumeChanged = false;
       }
 
-      await this.AVTransportService.SetAVTransportURI({ InstanceID: 0, CurrentURI: originalMediaInfo.CurrentURI, CurrentURIMetaData: originalMediaInfo.CurrentURIMetaData });
+      await this.AVTransportService.SetAVTransportURI(
+        {
+          InstanceID: 0,
+          CurrentURI: originalMediaInfo.CurrentURI,
+          CurrentURIMetaData: originalMediaInfo.CurrentURIMetaData,
+        },
+      ).catch((err) => {
+        this.debug('Error settingAVTransportURI, but this shouldn\'t stop the queue:  %o', err);
+      });
       if (options.delayMs !== undefined) await AsyncHelper.Delay(options.delayMs);
 
       if (originalPositionInfo.Track > 1 && originalMediaInfo.NrTracks > 1) {
@@ -1399,7 +1407,9 @@ export default class SonosDevice extends SonosDeviceBase {
       }
 
       if (originalState === TransportState.Playing || originalState === TransportState.Transitioning) {
-        await this.AVTransportService.Play({ InstanceID: 0, Speed: '1' });
+        await this.AVTransportService.Play({ InstanceID: 0, Speed: '1' }).catch((err) => {
+          this.debug('Reverting back track time failed, happens for some music services (radio or stream). %o', err);
+        });
       }
     }
 


### PR DESCRIPTION
# 141 Harden PlayNotificationTwo against some errors

## Description

This hardens the PlayNotificationTwo functionality against some errors, to ensure other items in queue might be able to continue.

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **beta branch** (left side). Also you should start *your branch* off *svrooij/node-sonos-ts/beta*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

💔 Thank you!
