### PR TITLE
Use zone events instead of pull

### DIFF
--- a/examples/use-manager.js
+++ b/examples/use-manager.js
@@ -60,5 +60,5 @@ process.on('SIGINT', () => {
   manager.CancelSubscription()
   setTimeout(() => {
     process.exit(0)
-  }, 200)
+  }, 300)
 })

--- a/src/services/base-service.ts
+++ b/src/services/base-service.ts
@@ -16,6 +16,7 @@ import { EventsError, EventsErrorCode } from '../models/event-errors';
 import SonosError from '../models/sonos-error';
 import HttpError from '../models/http-error';
 import { SonosUpnpError } from '../models/sonos-upnp-error';
+import AsyncHelper from '../helpers/async-helper';
 
 /**
  * Base Service class will handle all the requests to the sonos device.
@@ -356,7 +357,13 @@ export default abstract class BaseService <TServiceEvent> {
       this.events = new EventEmitter();
       this.events.on('removeListener', async (eventName: string | symbol) => {
         this.debug('Listener removed for %s', eventName);
-
+        // The ZoneGroupTopology service might resubscribe really soon after unsubscribing.
+        // Because we don't want it to cancel the subscription we wait 100 ms just to make sure there aren't any new subscriptions before unsubscribing
+        if(this.serviceNane === 'ZoneGroupTopology') {
+          this.debug('Waiting 100ms before unsubscribing');
+          await AsyncHelper.Delay(100);
+        }
+        
         const events = this.events?.eventNames().filter((e) => e !== 'removeListener' && e !== 'newListener' && e !== ServiceEvents.SubscriptionError);
         if (this.sid !== undefined && events?.length === 0) {
           await this.cancelSubscription()
@@ -368,12 +375,13 @@ export default abstract class BaseService <TServiceEvent> {
       });
       this.events.on('newListener', async (eventName: string | symbol) => {
         if (eventName === ServiceEvents.SubscriptionError) return;
-        this.debug('Listener added for %s  (sid: \'%s\', SONOS_DISABLE_EVENTS: %o)', eventName, this.sid, (typeof process.env.SONOS_DISABLE_EVENTS === 'undefined'));
-        if (this.sid === undefined && process.env.SONOS_DISABLE_EVENTS === undefined) {
+        const eventsEnabled = (process.env.SONOS_DISABLE_EVENTS === undefined || process.env.SONOS_DISABLE_EVENTS !== 'true');
+        this.debug('Listener added for %s  (sid: \'%s\', SONOS_DISABLE_EVENTS: %o)', eventName, this.sid, !eventsEnabled);
+        if (this.sid === undefined && eventsEnabled) {
           this.debug('Subscribing to events');
           await this.subscribeForEvents()
             .catch((err: Error) => {
-              this.debug('Subscriping for events failed', err);
+              this.debug('Subscribing for events failed', err);
               this.emitEventsError(new EventsError(EventsErrorCode.SubscribeFailed, err));
             });
         }

--- a/src/services/base-service.ts
+++ b/src/services/base-service.ts
@@ -359,11 +359,11 @@ export default abstract class BaseService <TServiceEvent> {
         this.debug('Listener removed for %s', eventName);
         // The ZoneGroupTopology service might resubscribe really soon after unsubscribing.
         // Because we don't want it to cancel the subscription we wait 100 ms just to make sure there aren't any new subscriptions before unsubscribing
-        if(this.serviceNane === 'ZoneGroupTopology') {
+        if (this.serviceNane === 'ZoneGroupTopology') {
           this.debug('Waiting 100ms before unsubscribing');
           await AsyncHelper.Delay(100);
         }
-        
+
         const events = this.events?.eventNames().filter((e) => e !== 'removeListener' && e !== 'newListener' && e !== ServiceEvents.SubscriptionError);
         if (this.sid !== undefined && events?.length === 0) {
           await this.cancelSubscription()

--- a/src/sonos-manager.ts
+++ b/src/sonos-manager.ts
@@ -71,26 +71,26 @@ export default class SonosManager {
         }
         throw err;
       });
-    let success = this.InitializeWithGroups(groups);
+    const success = this.InitializeWithGroups(groups);
     return this.SubscribeForGroupEvents(success);
   }
 
   private async LoadAllGroups(): Promise<ZoneGroup[]> {
-    this.debug('LoadAllGroups()')
+    this.debug('LoadAllGroups()');
     if (this.zoneService === undefined) throw new Error('Manager is\'t initialized');
     return await this.zoneService.GetParsedZoneGroupState();
   }
 
   private async LoadAllGroupsWithEvent(): Promise<ZoneGroup[]> {
-    this.debug('LoadAllGroupsWithEvent()')
+    this.debug('LoadAllGroupsWithEvent()');
     if (this.zoneService === undefined) throw new Error('Manager is\'t initialized');
     return await AsyncHelper
       .AsyncEvent<ZoneGroupTopologyServiceEvent>(this.zoneService.Events, ServiceEvents.ServiceEvent, 5)
       .then((data) => {
         if (!Array.isArray(data.ZoneGroupState)) {
-          throw new Error("No groups in event")
+          throw new Error('No groups in event');
         }
-        return data.ZoneGroupState
+        return data.ZoneGroupState;
       });
   }
 

--- a/src/sonos-manager.ts
+++ b/src/sonos-manager.ts
@@ -7,6 +7,8 @@ import SonosDeviceDiscovery from './sonos-device-discovery';
 import { ServiceEvents, PlayNotificationOptions, PlayTtsOptions } from './models';
 import IpHelper from './helpers/ip-helper';
 import TtsHelper from './helpers/tts-helper';
+import AsyncHelper from './helpers/async-helper';
+import SonosError from './models/sonos-error';
 /**
  * The SonosManager will manage the logical devices for you. It will also manage group updates so be sure to call .Close on exit to remove open listeners.
  *
@@ -59,14 +61,37 @@ export default class SonosManager {
 
   private async Initialize(): Promise<boolean> {
     this.debug('Initialize()');
-    const groups = await this.LoadAllGroups();
-    const success = this.InitializeWithGroups(groups);
+    const groups = await this
+      .LoadAllGroups()
+      .catch((err) => {
+        this.debug('Error loading groups with pull %o', err);
+        if (err instanceof SonosError && err.UpnpErrorCode === 501) {
+          // This happens with big systems, try loading with events
+          return this.LoadAllGroupsWithEvent();
+        }
+        throw err;
+      });
+    let success = this.InitializeWithGroups(groups);
     return this.SubscribeForGroupEvents(success);
   }
 
   private async LoadAllGroups(): Promise<ZoneGroup[]> {
+    this.debug('LoadAllGroups()')
     if (this.zoneService === undefined) throw new Error('Manager is\'t initialized');
     return await this.zoneService.GetParsedZoneGroupState();
+  }
+
+  private async LoadAllGroupsWithEvent(): Promise<ZoneGroup[]> {
+    this.debug('LoadAllGroupsWithEvent()')
+    if (this.zoneService === undefined) throw new Error('Manager is\'t initialized');
+    return await AsyncHelper
+      .AsyncEvent<ZoneGroupTopologyServiceEvent>(this.zoneService.Events, ServiceEvents.ServiceEvent, 5)
+      .then((data) => {
+        if (!Array.isArray(data.ZoneGroupState)) {
+          throw new Error("No groups in event")
+        }
+        return data.ZoneGroupState
+      });
   }
 
   private InitializeWithGroups(groups: ZoneGroup[]): boolean {


### PR DESCRIPTION
# Sonos manager now falls back onto using events if fetching all groups fail

## Description

Large systems, with 20+ speakers, would no longer answer to the `GetParsedZoneGroupState()` method of the `ZoneGroupService`, but they do send out events. Those events also include all the details that are required for loading the entire system. For now this PR uses the events as a fallback. So if fetching fails, it will try with events.

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **beta branch** (left side). Also you should start *your branch* off *svrooij/node-sonos-ts/beta*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.
- [ ] Check you add tests for added code.

💔 Thank you!
