### PR TITLE
Token refresh smapi client

### DIFF
--- a/src/musicservices/smapi-client.ts
+++ b/src/musicservices/smapi-client.ts
@@ -281,7 +281,8 @@ export class SmapiClient {
     }
     if (typeof result.Envelope.Body.Fault !== 'undefined') {
       const fault = result.Envelope.Body.Fault;
-      if (!isRetryWithNewCredentials && fault.faultstring === 'tokenRefreshRequired') {
+      if (!isRetryWithNewCredentials && fault.faultstring["#text"] ===
+          SmapiClientErrors.TokenRefreshRequiredError) {
         this.debug('Saving new tokens');
         // Set new tokens, maybe result in event?
         this.authToken = fault.detail?.refreshAuthTokenResult?.authToken;


### PR DESCRIPTION
Intending to finish fixing #200 

SmapiClient should take the new token when `faultstring` is `"tokenRefreshRequired"`, current error condition is not made properly (string being within a `#text` entry) 