### PR TITLE
fix: SonosDevice.GroupId never updates after initial group setup

### DIFF
--- a/src/sonos-device.ts
+++ b/src/sonos-device.ts
@@ -918,7 +918,7 @@ export default class SonosDevice extends SonosDeviceBase {
   // #region Group stuff
   private boundHandleGroupUpdate = this.handleGroupUpdate.bind(this);
 
-  private handleGroupUpdate(data: { coordinator: SonosDevice | undefined; name: string; groupdId: string | undefined }): void {
+  private handleGroupUpdate(data: { coordinator: SonosDevice | undefined; name: string; groupId: string | undefined }): void {
     if (data.coordinator && data.coordinator?.uuid !== this.Uuid && (!this.coordinator || this.coordinator?.Uuid !== data.coordinator?.Uuid)) {
       this.debug('Coordinator changed for %s', this.uuid);
       this.coordinator?.events?.removeListener('simpleTransportState', this.boundHandleCoordinatorSimpleStateEvent);
@@ -951,8 +951,8 @@ export default class SonosDevice extends SonosDeviceBase {
       }
     }
 
-    if (data.groupdId && data.groupdId !== this.groupId) {
-      this.groupId = data.groupdId;
+    if (data.groupId && data.groupId !== this.groupId) {
+      this.groupId = data.groupId;
       this.debug('GroupId changed for %s to %s', this.uuid, this.groupId);
       if (this.events !== undefined) {
         this.events.emit(SonosEvents.GroupId, this.groupId);

--- a/src/tests/sonos-device.test.ts
+++ b/src/tests/sonos-device.test.ts
@@ -1298,5 +1298,20 @@ describe('SonosDevice', () => {
       expect(device.GroupName).toEqual(newGroupName);
       done();
     });
+
+    it('Updates group id', (done) => {
+      const groupName = 'Special sonos group';
+      const groupId = 'RINCON_000FFFFFF4AA01400:1';
+      const newGroupId = 'RINCON_000FFFFFF4AA01400:2';
+      const name = 'Office';
+      const uuid = 'fake-uuid';
+      const emitter = new EventEmitter();
+      const device = new SonosDevice('localhost', 1400, uuid, name, { name: groupName, managerEvents: emitter, groupId });
+      expect(device.GroupId).toEqual(groupId);
+
+      emitter.emit(uuid, { name: groupName, groupId: newGroupId });
+      expect(device.GroupId).toEqual(newGroupId);
+      done();
+    });
   });
 });


### PR DESCRIPTION
## Problem

`SonosDevice.handleGroupUpdate()` checks `data.groupdId` (typo, extra "d"), but `SonosManager` emits the field as `groupId` everywhere it builds the group-update payload. The condition is therefore always `false`, so `GroupId` stays frozen at whatever value was passed into the constructor at `InitializeWithGroups()` time and never reflects a later regroup or coordinator change - unlike `.Coordinator`, `.GroupName` and `.IsCoordinator`, which all update correctly via the same event path.

## Fix

Corrected the property name in `handleGroupUpdate`'s parameter type and body so it reads `data.groupId`, matching what `SonosManager` actually sends.

## Testing

Added a test under "Group options in constructor" mirroring the existing "Updates group name" test, verifying `GroupId` is set from the constructor and updates when the manager emits a new value.

Not a breaking change - this only makes an already-documented property behave as intended.