### PR TITLE
feat: expose r:resMD as Track.ResMD when parsing favorites

### DIFF
--- a/src/helpers/metadata-helper.ts
+++ b/src/helpers/metadata-helper.ts
@@ -31,6 +31,7 @@ export default class MetadataHelper {
       ParentId: didlItem.parentID ?? didlItem.parentID,
       TrackUri: undefined,
       ProtocolInfo: undefined,
+      ResMD: XmlHelper.DecodeHtml(didlItem['r:resMD']),
     };
     if (didlItem['r:streamContent'] && typeof didlItem['r:streamContent'] === 'string' && track.Artist === undefined) {
       const streamContent = didlItem['r:streamContent'].split('-');

--- a/src/models/track.ts
+++ b/src/models/track.ts
@@ -10,4 +10,10 @@ export interface Track {
   TrackUri?: string;
   ProtocolInfo?: string;
   CdUdn?: string;
+  /**
+   * Pre-encoded DIDL-Lite metadata (`r:resMD`) for the underlying playable resource, only
+   * present on some favorites. Use this as CurrentURIMetaData instead of the favorite's own
+   * UpnpClass, which describes the favorite entry itself and isn't valid for playback.
+   */
+  ResMD?: string;
 }

--- a/src/tests/helpers/metadata-helper.test.ts
+++ b/src/tests/helpers/metadata-helper.test.ts
@@ -645,6 +645,29 @@ describe('MetadataHelper', () => {
       expect(result).toHaveProperty('ItemId', id);
       done();
     });
+
+    it('decodes r:resMD into the raw DIDL-Lite metadata of the underlying resource', (done) => {
+      const innerDidl = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="F00090020s106914" parentID="F000c0008s106914" restricted="true"><dc:title>Q-Dance Hard</dc:title><upnp:class>object.item.audioItem.audioBroadcast</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON65031_</desc></item></DIDL-Lite>';
+      // As it arrives from the XML parser, still one level of html-entity-encoding away from innerDidl.
+      const encodedResMd = innerDidl.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+      const didl = {
+        'dc:title': 'Q-Dance Hard',
+        'upnp:class': 'object.itemobject.item.sonos-favorite',
+        'r:resMD': encodedResMd,
+      };
+      const result = MetadataHelper.ParseDIDLTrack(didl, 'fake_host');
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('ResMD', innerDidl);
+      done();
+    });
+
+    it('leaves ResMD undefined when r:resMD is absent', (done) => {
+      const didl = { 'dc:title': 'No favorite metadata here' };
+      const result = MetadataHelper.ParseDIDLTrack(didl, 'fake_host');
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('ResMD', undefined);
+      done();
+    });
   });
 
   describe('TrackToMetaData', () => {

--- a/src/tests/sonos-device.test.ts
+++ b/src/tests/sonos-device.test.ts
@@ -414,6 +414,7 @@ describe('SonosDevice', () => {
       expect(result).toHaveProperty('NumberReturned', 6);
       expect(result).toHaveProperty('TotalMatches', 6);
       expect(result).toHaveProperty('UpdateID', 3);
+      expect(result.Result[0]).toHaveProperty('ResMD', '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/"><item id="10032020spotify%3atrack%3a7nDoBWDvf02SyD8kEQuuPO" parentID="100e206cspotify%3aartistTopTracks%3a5q8HGNo0BjLWaTAhRtbwxa" restricted="true"><dc:title>Bottoms Up</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON2311_X_#Svc2311-0-Token</desc></item></DIDL-Lite>');
     });
   });
 


### PR DESCRIPTION
## Problem

Sonos favorites report their own container `UpnpClass` (often the well-known malformed value `object.itemobject.item.sonos-favorite`), which is not a valid `CurrentURIMetaData` class for playback - passing a favorite `Track` straight into `SetAVTransportURI` gets rejected by the speaker with UPnP error 402.

The actual playable resource's metadata (with the correct `upnp:class` for the underlying track/stream) is carried separately in the `r:resMD` attribute of the favorite's DIDL-Lite item, but `MetadataHelper.ParseDIDLTrack` silently discarded it, forcing consumers to re-parse the raw `ContentDirectoryService.Browse` response themselves to get at it.

## Fix

`ParseDIDLTrack` now decodes `r:resMD` (when present) into `Track.ResMD` - a ready-to-use, already-decoded DIDL-Lite XML string. Consumers can pass it directly as a raw `CurrentURIMetaData` string to `AVTransportService.SetAVTransportURI` to play a favorite without hitting the 402.

## Testing

- Unit tests on `MetadataHelper.ParseDIDLTrack` covering decoding of `r:resMD` and the absent case.
- Extended the existing `GetFavorites()` end-to-end test with an assertion on the decoded `ResMD` value using a real captured Sonos favorites response.

Purely additive (new optional field) - not a breaking change.