### PR TITLE
feat: add MetadataHelper.IsRadioStream() to detect live/non-skippable streams

### DIFF
--- a/src/helpers/metadata-helper.ts
+++ b/src/helpers/metadata-helper.ts
@@ -105,6 +105,30 @@ export default class MetadataHelper {
   }
 
   /**
+   * IsRadioStream checks if a (currently playing) track URI is a live/radio-style stream, as
+   * opposed to a regular skippable track. Useful to decide whether to disable next/previous/
+   * shuffle controls in a UI.
+   *
+   * @static
+   * @param {string | undefined} trackUri Internal Sonos track URI (e.g. from currently playing track)
+   * @returns {boolean} true if the URI is a live stream that shouldn't be treated as skippable
+   * @memberof MetadataHelper
+   */
+  static IsRadioStream(trackUri: string | undefined): boolean {
+    if (!trackUri) return false;
+    return trackUri.startsWith('x-sonosapi-stream:')
+      || trackUri.startsWith('x-sonosapi-radio:')
+      || trackUri.startsWith('x-sonosapi-hls:')
+      || trackUri.startsWith('x-rincon-stream:')
+      || trackUri.startsWith('x-rincon-mp3radio:')
+      || trackUri.startsWith('aac:')
+      || trackUri.startsWith('pndrradio:')
+      // Sonos Radio (Deezer-powered) delivers individual tracks via x-sonos-http, but they
+      // are part of a radio stream and not individually skippable.
+      || (trackUri.startsWith('x-sonos-http:') && trackUri.includes('-DZR:'));
+  }
+
+  /**
    * GetSimpleUri will convert an internal Sonos track URI back to a simple service URI
    * that can be used with GuessTrack or GuessMetaDataAndTrackUri.
    *

--- a/src/helpers/metadata-helper.ts
+++ b/src/helpers/metadata-helper.ts
@@ -109,6 +109,12 @@ export default class MetadataHelper {
    * opposed to a regular skippable track. Useful to decide whether to disable next/previous/
    * shuffle controls in a UI.
    *
+   * This is a synchronous, URI-pattern based guess with no device round-trip, intended for
+   * callers that already have a `TrackUri` (e.g. from a `GetPositionInfo` poll or an AVTransport
+   * event) and need an answer on every such event without an extra request per track change.
+   * If a live round-trip to the device is acceptable, `AVTransportService.GetCurrentTransportActions()`
+   * is the more authoritative source, since it reflects the actual current playback session.
+   *
    * @static
    * @param {string | undefined} trackUri Internal Sonos track URI (e.g. from currently playing track)
    * @returns {boolean} true if the URI is a live stream that shouldn't be treated as skippable

--- a/src/tests/helpers/metadata-helper.test.ts
+++ b/src/tests/helpers/metadata-helper.test.ts
@@ -499,6 +499,33 @@ describe('MetadataHelper', () => {
     });
   });
 
+  describe('IsRadioStream', () => {
+    it('returns false for undefined', () => {
+      expect(MetadataHelper.IsRadioStream(undefined)).toBe(false);
+    });
+
+    it.each([
+      'x-sonosapi-stream:s24896?sid=254&flags=8224&sn=0',
+      'x-sonosapi-radio:spotify:artistRadio:1234?sid=9',
+      'x-sonosapi-hls:sn2vrdgs.stream?sid=284',
+      'x-rincon-stream:RINCON_000FFFFFF01400',
+      'x-rincon-mp3radio://http://stream.example.com/live.mp3',
+      'aac:http://stream.example.com/live.aac',
+      'pndrradio:1234?sid=236',
+      'x-sonos-http:track-abc123-DZR:1.mp4?sid=519',
+    ])('returns true for radio-style URI %s', (uri) => {
+      expect(MetadataHelper.IsRadioStream(uri)).toBe(true);
+    });
+
+    it('returns false for a regular Deezer library track', () => {
+      expect(MetadataHelper.IsRadioStream('x-sonos-http:tr:123456789.mp3?sid=519')).toBe(false);
+    });
+
+    it('returns false for a regular skippable track', () => {
+      expect(MetadataHelper.IsRadioStream('x-sonos-spotify:spotify:track:6sYJuVcEu4gFHmeTLdHzRz?sid=9')).toBe(false);
+    });
+  });
+
   describe('ParseDIDLTrack', () => {
     it('returns undefined for undefined input', () => {
       const result = MetadataHelper.ParseDIDLTrack(undefined, 'fake_host');


### PR DESCRIPTION
## Problem

Consumers building playback UIs (e.g. disabling next/previous/shuffle) need to know whether the currently playing track is a live/radio-style stream rather than a regular skippable track. `MetadataHelper.GetSimpleUri()` reverses a track URI back to a portable service reference, but doesn't answer this question, and there's no equivalent helper elsewhere in the SDK.

## Fix

Added `MetadataHelper.IsRadioStream(trackUri)`, a boolean check covering the known non-skippable-stream URI schemes: `x-sonosapi-stream:`, `x-sonosapi-radio:`, `x-sonosapi-hls:`, `x-rincon-stream:`, `x-rincon-mp3radio:`, `aac:`, `pndrradio:`, and Sonos Radio's Deezer-powered per-track delivery (`x-sonos-http:` URIs containing `-DZR:`, which arrive per-track but aren't individually skippable).

## Testing

Added unit tests covering each recognized scheme plus negative cases (undefined, a regular Deezer library track, a regular Spotify track).

Purely additive - not a breaking change.